### PR TITLE
Move gcp connections to google.connection

### DIFF
--- a/pkg/model/spec.go
+++ b/pkg/model/spec.go
@@ -109,5 +109,20 @@ type GCPSpec struct {
 }
 
 type GCPDetails struct {
+	Connection *GCPConnection
+	Project    string
+
+	// deprecated
+	ServiceAccountKey string `json:"serviceAccountKey"`
+}
+
+func (gd *GCPDetails) GetServiceAccountKey() string {
+	if gd.Connection.ServiceAccountKey == "" {
+		return gd.ServiceAccountKey
+	}
+	return gd.Connection.ServiceAccountKey
+}
+
+type GCPConnection struct {
 	ServiceAccountKey string `json:"serviceAccountKey"`
 }

--- a/pkg/model/spec.go
+++ b/pkg/model/spec.go
@@ -79,7 +79,7 @@ type AWSConnection struct {
 }
 
 type AWSDetails struct {
-	Connection *AWSConnection
+	Connection AWSConnection
 
 	// deprecated
 	AccessKeyID string
@@ -109,7 +109,7 @@ type GCPSpec struct {
 }
 
 type GCPDetails struct {
-	Connection *GCPConnection
+	Connection GCPConnection
 	Project    string
 
 	// deprecated

--- a/pkg/task/gcp.go
+++ b/pkg/task/gcp.go
@@ -24,7 +24,7 @@ func (ti *TaskInterface) ProcessGCP(directory string) error {
 	}
 
 	destination := filepath.Join(directory, "credentials.json")
-	err := taskutil.WriteToFile(destination, spec.Google.ServiceAccountKey)
+	err := taskutil.WriteToFile(destination, spec.Google.GetServiceAccountKey())
 
 	if err != nil {
 		return err

--- a/pkg/task/gcp_test.go
+++ b/pkg/task/gcp_test.go
@@ -1,0 +1,74 @@
+package task
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/puppetlabs/relay-sdk-go/pkg/model"
+	"github.com/puppetlabs/relay-sdk-go/pkg/taskutil"
+	"github.com/puppetlabs/relay-sdk-go/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCPConnectionBackwardCompatibility(t *testing.T) {
+	tests := []struct {
+		Spec          map[string]interface{}
+		ExpectedKey   string
+		ExpectedError bool
+	}{
+		{
+			Spec: map[string]interface{}{
+				"serviceAccountKey": "TEST KEY",
+			},
+			ExpectedKey: "TEST KEY",
+		},
+		{
+			Spec: map[string]interface{}{},
+		},
+		{
+			Spec: map[string]interface{}{
+				"somethingElse": "something else",
+			},
+			ExpectedError: true,
+		},
+		{
+			Spec: map[string]interface{}{
+				"connection": map[string]interface{}{
+					"serviceAccountKey": "TEST KEY",
+				},
+			},
+			ExpectedKey: "TEST KEY",
+		},
+	}
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			opts := testutil.MockMetadataAPIOptions{
+				SpecResponse: map[string]interface{}{
+					"value": test.Spec,
+				},
+			}
+
+			testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
+				opts := taskutil.DefaultPlanOptions{
+					Client:  ts.Client(),
+					SpecURL: fmt.Sprintf("%s/spec", ts.URL),
+				}
+
+				var spec model.GCPDetails
+				require.NoError(t, taskutil.PopulateSpecFromDefaultPlan(&spec, opts))
+
+				key := spec.GetServiceAccountKey()
+				if test.ExpectedError {
+					require.Empty(t, key)
+					//require.Error(t, err)
+				} else if test.ExpectedKey != "" {
+					require.Equal(t, test.ExpectedKey, key)
+				} else {
+					require.Empty(t, key)
+				}
+			}, opts)
+		})
+	}
+}


### PR DESCRIPTION
aws is under `aws.connection` and it would be nice to match. It would also be nice to be able to specify a project to override `google.connection.project_id` as needed.