### PR TITLE
Check for SSH connection before emitting SSH config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/golangci/golangci-lint v1.36.0
+	github.com/google/uuid v1.2.0
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/magiconair/properties v1.8.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=

--- a/pkg/model/spec.go
+++ b/pkg/model/spec.go
@@ -2,14 +2,11 @@ package model
 
 import (
 	"encoding/base64"
-	"errors"
 	"regexp"
 )
 
 var (
 	GitSSHURL = regexp.MustCompile(`^([a-z-]+)@([a-zA-Z0-9\-.]+):(.+)/(.+)(\.git)?$`)
-
-	ErrMalformedSSHURL = errors.New("SSH URL is malformed")
 )
 
 type CredentialSpec struct {
@@ -33,19 +30,10 @@ type GitDetails struct {
 	KnownHosts string `spec:"known_hosts"`
 }
 
-func (gd *GitDetails) ConfiguredRepository() (string, bool, error) {
-	if gd.Repository == "" {
-		return "", false, nil
-	}
-
-	matches := GitSSHURL.FindStringSubmatch(gd.Repository)
-	if len(matches) <= 1 {
-		return "", false, ErrMalformedSSHURL
-	}
-
-	host := matches[2]
-
-	return host, true, nil
+type GitSSHDetails struct {
+	Host       string
+	KnownHosts string
+	SSHKey     string
 }
 
 func (gd *GitDetails) ConfiguredSSHKey() (string, bool, error) {

--- a/pkg/task/git.go
+++ b/pkg/task/git.go
@@ -60,6 +60,11 @@ func gitURLComponents(url string) ([]string, error) {
 }
 
 func writeSSHConfig(resource *model.GitDetails) error {
+	sshKey, found, err := resource.ConfiguredSSHKey()
+	if err != nil || !found {
+		return err
+	}
+
 	gitConfig := taskutil.SSHConfig{}
 
 	matches, err := gitURLComponents(resource.Repository)
@@ -72,11 +77,6 @@ func writeSSHConfig(resource *model.GitDetails) error {
 	gitConfig.Order = make([]string, 0)
 	gitConfig.Order = append(gitConfig.Order, host)
 	gitConfig.Entries = make(map[string]taskutil.SSHEntry)
-
-	sshKey, found, err := resource.ConfiguredSSHKey()
-	if err != nil || !found {
-		return err
-	}
 
 	knownHosts, found, err := resource.ConfiguredKnownHosts()
 	if err != nil {

--- a/pkg/task/git_test.go
+++ b/pkg/task/git_test.go
@@ -120,12 +120,17 @@ func TestGitURLMatching(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.gitURL, func(t *testing.T) {
-			matches, err := gitURLComponents(c.gitURL)
+			gd := model.GitDetails{
+				Repository: c.gitURL,
+			}
+			matches, found, err := gd.ConfiguredRepository()
 
 			if !c.shouldMatch {
 				require.Error(t, err)
+				require.False(t, found)
 			} else {
 				require.NoError(t, err)
+				require.True(t, found)
 				require.GreaterOrEqual(t, len(matches), 4)
 			}
 		})

--- a/pkg/task/git_test.go
+++ b/pkg/task/git_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/puppetlabs/relay-sdk-go/pkg/model"
 	"github.com/puppetlabs/relay-sdk-go/pkg/taskutil"
 	"github.com/puppetlabs/relay-sdk-go/pkg/testutil"
@@ -21,7 +22,7 @@ func TestGitOutput(t *testing.T) {
 				"git": map[string]interface{}{
 					"ssh_key":     "<ssh_key>",
 					"known_hosts": "<known_hosts>",
-					"name":        "<name>",
+					"name":        uuid.New().String(),
 					"repository":  "<repository>",
 				},
 			},
@@ -32,7 +33,7 @@ func TestGitOutput(t *testing.T) {
 	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
 		// opts := taskutil.DefaultPlanOptions{
 		// 	Client:  ts.Client(),
-		// 	SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+		// 	SpecURL: fmt.Sprintf("%s/spec", ts.URL),
 		// }
 
 		// task := NewTaskInterface(opts)
@@ -103,35 +104,48 @@ func TestGitSSHKeyBackwardCompatibility(t *testing.T) {
 	}
 }
 
-func TestGitURLMatching(t *testing.T) {
+func TestGitSSHConfiguration(t *testing.T) {
 	cases := []struct {
 		gitURL      string
+		host        string
 		shouldMatch bool
 	}{
-		{gitURL: "git@github.com:example/example-repo", shouldMatch: true},
-		{gitURL: "git@github.com:example/example-repo.git", shouldMatch: true},
+		{gitURL: "git@github.com:example/example-repo", host: "github.com", shouldMatch: true},
+		{gitURL: "git@github.com:example/example-repo.git", host: "github.com", shouldMatch: true},
 		{gitURL: "git@github.com/example/example-repo.git", shouldMatch: false},
-		{gitURL: "foobar@github.com:example/example-repo", shouldMatch: true},
-		{gitURL: "foobar@github.com:example/example-repo.git", shouldMatch: true},
+		{gitURL: "foobar@github.com:example/example-repo", host: "github.com", shouldMatch: true},
+		{gitURL: "foobar@github.com:example/example-repo.git", host: "github.com", shouldMatch: true},
 		{gitURL: "foobar@github.com/example/example-repo.git", shouldMatch: false},
+		{gitURL: "git@github.com:example", shouldMatch: false},
+		{gitURL: "git@github.com/example", shouldMatch: false},
+		{gitURL: "git@example.com:example-org/example-repo", host: "example.com", shouldMatch: true},
+		{gitURL: "", shouldMatch: false},
 		{gitURL: "https://example.com", shouldMatch: false},
-		{gitURL: "git@example.com:example-org/example-repo", shouldMatch: true},
+		{gitURL: "https://example.com/example", shouldMatch: false},
+		{gitURL: "https://example.com:example", shouldMatch: false},
+		{gitURL: "https://example.com:example/example-repo.git", shouldMatch: false},
+		{gitURL: "https://example.com/example-org/example-repo", shouldMatch: false},
+		{gitURL: "https://example.com/example-org/example-repo.git", shouldMatch: false},
 	}
 
 	for _, c := range cases {
 		t.Run(c.gitURL, func(t *testing.T) {
-			gd := model.GitDetails{
+			gd := &model.GitDetails{
 				Repository: c.gitURL,
+				SSHKey:     "<ssh_key>",
+				KnownHosts: "<known_hosts>",
 			}
-			matches, found, err := gd.ConfiguredRepository()
+
+			ssh, err := configuredSSH(gd)
+
+			require.NoError(t, err)
 
 			if !c.shouldMatch {
-				require.Error(t, err)
-				require.False(t, found)
+				require.Empty(t, ssh)
 			} else {
-				require.NoError(t, err)
-				require.True(t, found)
-				require.GreaterOrEqual(t, len(matches), 4)
+				require.Equal(t, c.host, ssh.Host)
+				require.Equal(t, gd.SSHKey, ssh.SSHKey)
+				require.Equal(t, gd.KnownHosts, ssh.KnownHosts)
 			}
 		})
 	}


### PR DESCRIPTION
- Alters SSH configuration testing to call the main SSH configuration routine (instead of only testing the SSH URL matching).
- Adds additional test cases to the above.
- Inverts the SSH URL matching flow (i.e. an SSH URL indicates that we should check for the SSH Keys and Known Hosts and continue with SSH configuration, instead of the presence of SSH Keys indicating that an SSH URL must be used and aborting if it's not a valid SSH URL).
- Splits up routines to be smaller and more readable.
- Improves readability (and error handling) in general.
- Additional error messages can now be layered on (easier) if necessary. 